### PR TITLE
Especialidades por médico + busca de clínicas por raio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "dayjs": "1.11.12",
         "dotenv": "16.4.5",
         "fastify": "4.26.2",
+        "geolib": "3.3.4",
         "jsonwebtoken": "9.0.2",
         "nodemailer": "6.9.15",
         "zod": "3.23.4"
@@ -28,6 +29,7 @@
         "@eslint/js": "9.1.1",
         "@rocketseat/eslint-config": "2.2.2",
         "@types/bcryptjs": "2.4.6",
+        "@types/geolib": "2.0.3",
         "@types/jsonwebtoken": "9.0.9",
         "@types/node": "20.12.7",
         "@types/nodemailer": "6.4.16",
@@ -1450,6 +1452,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geolib": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/geolib/-/geolib-2.0.3.tgz",
+      "integrity": "sha512-y4ZFLXNiYfAhAxil8ODKE7R3xDc/sdgb5wpRPQefCBbtuO40fFpSdfeh3LNPfeM8qdkftNvhlgiYwe+lK6wp6g==",
       "dev": true,
       "license": "MIT"
     },
@@ -4542,6 +4551,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/geolib": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/geolib/-/geolib-3.3.4.tgz",
+      "integrity": "sha512-EicrlLLL3S42gE9/wde+11uiaYAaeSVDwCUIv2uMIoRBfNJCn8EsSI+6nS3r4TCKDO6+RQNM9ayLq2at+oZQWQ==",
+      "license": "MIT"
     },
     "node_modules/get-func-name": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@eslint/js": "9.1.1",
     "@rocketseat/eslint-config": "2.2.2",
     "@types/bcryptjs": "2.4.6",
+    "@types/geolib": "2.0.3",
     "@types/jsonwebtoken": "9.0.9",
     "@types/node": "20.12.7",
     "@types/nodemailer": "6.4.16",
@@ -52,6 +53,7 @@
     "dayjs": "1.11.12",
     "dotenv": "16.4.5",
     "fastify": "4.26.2",
+    "geolib": "3.3.4",
     "jsonwebtoken": "9.0.2",
     "nodemailer": "6.9.15",
     "zod": "3.23.4"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,14 +8,6 @@ datasource db {
   directUrl = env("DIRECT_URL")
 }
 
-model ClinicSpecialty {
-  id       Int    @id @default(autoincrement())
-  value    String
-  label    String
-  clinicId Int
-  clinic   Clinic @relation(fields: [clinicId], references: [id], onDelete: Cascade)
-}
-
 model ClinicHealthInsurance {
   id       Int    @id @default(autoincrement())
   value    String
@@ -47,7 +39,6 @@ model Clinic {
   longitude       Float?
   createdAt       DateTime                @default(now())
   healthInsurance ClinicHealthInsurance[]
-  specialty       ClinicSpecialty[]
   Consultation    Consultation[]
   Medic           Medic[]
 

--- a/src/docs/swagger-setup.ts
+++ b/src/docs/swagger-setup.ts
@@ -247,6 +247,48 @@ export async function setupSwagger(app: FastifyInstance) {
               }
             }
           },
+          ClinicSpecialtiesResponse: {
+            type: 'object',
+            properties: {
+              message: {
+                type: 'string',
+                example: 'Especialidades da clínica recuperadas com sucesso.'
+              },
+              data: {
+                type: 'object',
+                properties: {
+                  clinicId: {
+                    type: 'integer',
+                    example: 15,
+                    description: 'ID da clínica consultada'
+                  },
+                  specialties: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        value: {
+                          type: 'string',
+                          example: 'cardiologia',
+                          description: 'Valor formatado da especialidade (slug)'
+                        },
+                        label: {
+                          type: 'string',
+                          example: 'Cardiologia',
+                          description: 'Nome legível da especialidade'
+                        }
+                      }
+                    }
+                  },
+                  totalSpecialties: {
+                    type: 'integer',
+                    example: 4,
+                    description: 'Número total de especialidades'
+                  }
+                }
+              }
+            }
+          },
 
           // Medic schemas
           MedicRegister: {
@@ -539,6 +581,76 @@ export async function setupSwagger(app: FastifyInstance) {
               }
             }
           },
+        },
+        '/clinics/{clinicId}/specialties': {
+          get: {
+            summary: 'Obtém especialidades dos médicos de uma clínica',
+            tags: ['Clínicas'],
+            description: 'Retorna todas as especialidades distintas dos médicos autenticados que pertencem à clínica especificada. Apenas médicos com isAuthenticated = true são considerados.',
+            parameters: [
+              {
+                name: 'clinicId',
+                in: 'path',
+                required: true,
+                schema: { type: 'integer' },
+                description: 'ID da clínica',
+                example: 15
+              }
+            ],
+            responses: {
+              '200': {
+                description: 'Especialidades da clínica recuperadas com sucesso',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ClinicSpecialtiesResponse' }
+                  }
+                }
+              },
+              '400': {
+                description: 'Formato de ID da clínica inválido',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        message: {
+                          type: 'string',
+                          example: 'Formato de ID da clínica inválido.'
+                        },
+                        errors: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            properties: {
+                              code: { type: 'string' },
+                              message: { type: 'string' },
+                              path: { type: 'array', items: { type: 'string' } }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              '404': {
+                description: 'Clínica não encontrada',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Error' }
+                  }
+                }
+              },
+              '500': {
+                description: 'Erro interno do servidor',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Error' }
+                  }
+                }
+              }
+            }
+          }
         },
         '/clinics/active': {
           get: {

--- a/src/docs/swagger-setup.ts
+++ b/src/docs/swagger-setup.ts
@@ -182,22 +182,12 @@ export async function setupSwagger(app: FastifyInstance) {
           ClinicRegister: {
             type: 'object',
             required: [
-              'name', 'specialty', 'healthInsurance', 'phone', 'cellPhone', 'whatsapp',
+              'name', 'healthInsurance', 'phone', 'cellPhone', 'whatsapp',
               'hasNumber', 'houseNumber', 'acceptTerm', 'email', 'cnpj', 'password',
               'passwordConfirmation', 'address', 'cep', 'city', 'state', 'neighborhood'
             ],
             properties: {
               name: { type: 'string', example: 'Clínica Saúde Plena' },
-              specialty: {
-                type: 'array',
-                items: {
-                  type: 'object',
-                  properties: {
-                    value: { type: 'string', example: 'cardiologia' },
-                    label: { type: 'string', example: 'Cardiologia' }
-                  }
-                }
-              },
               healthInsurance: {
                 type: 'array',
                 items: {
@@ -580,16 +570,6 @@ export async function setupSwagger(app: FastifyInstance) {
                               state: { type: 'string', example: 'SP' },
                               neighborhood: { type: 'string', example: 'Bela Vista' },
                               complement: { type: 'string', example: 'Sala 501', nullable: true },
-                              specialty: {
-                                type: 'array',
-                                items: {
-                                  type: 'object',
-                                  properties: {
-                                    value: { type: 'string', example: 'cardiologia' },
-                                    label: { type: 'string', example: 'Cardiologia' }
-                                  }
-                                }
-                              },
                               healthInsurance: {
                                 type: 'array',
                                 items: {
@@ -786,16 +766,6 @@ export async function setupSwagger(app: FastifyInstance) {
                             state: { type: 'string', example: 'SP' },
                             neighborhood: { type: 'string', example: 'Bela Vista' },
                             complement: { type: 'string', example: 'Sala 501' },
-                            specialty: {
-                              type: 'array',
-                              items: {
-                                type: 'object',
-                                properties: {
-                                  value: { type: 'string', example: 'cardiologia' },
-                                  label: { type: 'string', example: 'Cardiologia' }
-                                }
-                              }
-                            },
                             healthInsurance: {
                               type: 'array',
                               items: {

--- a/src/http/controllers/clinic/getClinicDetails.ts
+++ b/src/http/controllers/clinic/getClinicDetails.ts
@@ -49,7 +49,6 @@ export const getClinicDetails = async (
       latitude: clinic.latitude,
       longitude: clinic.longitude,
       createdAt: clinic.createdAt,
-      specialty: clinic.specialty || [],
       healthInsurance: clinic.healthInsurance || [],
       // Não incluir campos sensíveis como password_hash, isAuthenticated
     };

--- a/src/http/controllers/clinic/getClinicSpecialties.ts
+++ b/src/http/controllers/clinic/getClinicSpecialties.ts
@@ -1,0 +1,74 @@
+import { FastifyRequest, FastifyReply } from "fastify";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+
+export const getClinicSpecialties = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const getClinicSpecialtiesSchema = z.object({
+    clinicId: z.string().transform((val) => {
+      const num = parseInt(val, 10);
+      if (isNaN(num) || num <= 0) {
+        throw new Error("ID da clínica deve ser um número positivo");
+      }
+      return num;
+    }),
+  });
+
+  try {
+    const { clinicId } = getClinicSpecialtiesSchema.parse(request.params);
+
+    // Busca a clínica para verificar se existe
+    const clinic = await prisma.clinic.findUnique({
+      where: { id: clinicId }
+    });
+
+    if (!clinic) {
+      return reply.status(404).send({
+        message: "Clínica não encontrada."
+      });
+    }
+
+    // Busca todas as especialidades dos médicos desta clínica
+    const specialties = await prisma.medicSpecialty.findMany({
+      where: {
+        medic: {
+          clinicId: clinicId,
+          isAuthenticated: true
+        }
+      },
+      select: {
+        specialty: true
+      },
+      distinct: ['specialty']
+    });
+
+    // Formata as especialidades
+    const formattedSpecialties = specialties.map(spec => ({
+      value: spec.specialty.toLowerCase().replace(/\s+/g, '-'),
+      label: spec.specialty
+    }));
+
+    return reply.status(200).send({
+      message: "Especialidades da clínica recuperadas com sucesso.",
+      data: {
+        clinicId,
+        specialties: formattedSpecialties.sort((a, b) => a.label.localeCompare(b.label)),
+        totalSpecialties: formattedSpecialties.length
+      },
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return reply.status(400).send({
+        message: "Formato de ID da clínica inválido.",
+        errors: error.errors,
+      });
+    }
+
+    console.error("Erro ao buscar especialidades da clínica:", error);
+    return reply.status(500).send({
+      message: "Erro interno do servidor.",
+    });
+  }
+};

--- a/src/http/controllers/clinic/getClinicsByProximity.ts
+++ b/src/http/controllers/clinic/getClinicsByProximity.ts
@@ -1,0 +1,175 @@
+import { FastifyRequest, FastifyReply } from "fastify";
+import { z } from "zod";
+import { makeGetAllActivateClinicsUseCase } from "@/use-cases/factories/clinic/make-get-all-active-clinics-use-case";
+import { geocodeAddress, GeocodingError } from "@/utils/geocoding/nominatim-service";
+import { getDistance } from "geolib";
+import { Clinic, ClinicHealthInsurance } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+interface AddressInput {
+  address: string;
+  cep: string;
+  city: string;
+  state: string;
+  neighborhood: string;
+  houseNumber: string;
+}
+
+interface ClinicWithDistance {
+  id: number;
+  name: string;
+  phone: string;
+  cellPhone: string;
+  whatsapp: string;
+  hasNumber: boolean;
+  houseNumber: string;
+  email: string;
+  cnpj: string;
+  address: string;
+  cep: string;
+  city: string;
+  state: string;
+  neighborhood: string;
+  complement: string | null;
+  latitude: number;
+  longitude: number;
+  createdAt: Date;
+  healthInsurance: ClinicHealthInsurance[];
+  distanceInKm: number;
+}
+
+export const getClinicsByProximity = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const getClinicsByProximitySchema = z.object({
+    address: z.string().min(1, "Endereço é obrigatório"),
+    cep: z.string().min(8, "CEP deve ter pelo menos 8 caracteres"),
+    city: z.string().min(1, "Cidade é obrigatória"),
+    state: z.string().min(2, "Estado deve ter pelo menos 2 caracteres"),
+    neighborhood: z.string().min(1, "Bairro é obrigatório"),
+    houseNumber: z.string().min(1, "Número da casa é obrigatório"),
+    radiusInKm: z.number().min(0.1).max(10000, "Raio deve estar entre 0.1 e 10000 km"),
+  });
+
+  try {
+    const {
+      address,
+      cep,
+      city,
+      state,
+      neighborhood,
+      houseNumber,
+      radiusInKm,
+    } = getClinicsByProximitySchema.parse(request.body);
+
+    // Geocodificar o endereço fornecido pelo paciente
+    const addressInput: AddressInput = {
+      address,
+      cep,
+      city,
+      state,
+      neighborhood,
+      houseNumber,
+    };
+
+    let patientCoordinates;
+    try {
+      patientCoordinates = await geocodeAddress(addressInput);
+    } catch (error) {
+      if (error instanceof GeocodingError) {
+        return reply.status(400).send({
+          message: "Não foi possível encontrar coordenadas para o endereço fornecido.",
+          error: error.message,
+        });
+      }
+      throw error;
+    }
+
+    // Buscar todas as clínicas ativas
+    const clinics = await prisma.clinic.findMany({
+      where: {
+        isAuthenticated: true,
+      },
+      include: {
+        healthInsurance: true,
+      },
+    });
+
+    // Filtrar clínicas que têm coordenadas e calcular distâncias
+    const clinicsWithDistance: ClinicWithDistance[] = [];
+
+    for (const clinic of clinics) {
+      // Pular clínicas sem coordenadas
+      if (!clinic.latitude || !clinic.longitude) {
+        continue;
+      }
+
+      // Calcular distância usando geolib
+      const distanceInMeters = getDistance(
+        {
+          latitude: patientCoordinates.latitude,
+          longitude: patientCoordinates.longitude,
+        },
+        {
+          latitude: clinic.latitude,
+          longitude: clinic.longitude,
+        }
+      );
+
+      const distanceInKm = distanceInMeters / 1000;
+
+      // Filtrar apenas clínicas dentro do raio especificado
+      if (distanceInKm <= radiusInKm) {
+        clinicsWithDistance.push({
+          id: clinic.id,
+          name: clinic.name,
+          phone: clinic.phone,
+          cellPhone: clinic.cellPhone,
+          whatsapp: clinic.whatsapp,
+          hasNumber: clinic.hasNumber,
+          houseNumber: clinic.houseNumber,
+          email: clinic.email,
+          cnpj: clinic.cnpj,
+          address: clinic.address,
+          cep: clinic.cep,
+          city: clinic.city,
+          state: clinic.state,
+          neighborhood: clinic.neighborhood,
+          complement: clinic.complement,
+          latitude: clinic.latitude,
+          longitude: clinic.longitude,
+          createdAt: clinic.createdAt,
+          healthInsurance: clinic.healthInsurance,
+          distanceInKm: Math.round(distanceInKm * 100) / 100, // Arredondar para 2 casas decimais
+        });
+      }
+    }
+
+    // Ordenar por distância (mais próximo primeiro)
+    clinicsWithDistance.sort((a, b) => a.distanceInKm - b.distanceInKm);
+
+    return reply.status(200).send({
+      message: `${clinicsWithDistance.length} clínicas encontradas em um raio de ${radiusInKm}km.`,
+      data: {
+        patientCoordinates,
+        searchRadius: radiusInKm,
+        totalFound: clinicsWithDistance.length,
+        clinics: clinicsWithDistance,
+      },
+    });
+
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return reply.status(400).send({
+        message: "Dados de entrada inválidos.",
+        errors: error.errors,
+      });
+    }
+
+    console.error("Erro ao buscar clínicas por proximidade:", error);
+    return reply.status(500).send({
+      message: "Erro interno do servidor.",
+    });
+  }
+};

--- a/src/http/controllers/clinic/registerClinic.ts
+++ b/src/http/controllers/clinic/registerClinic.ts
@@ -14,12 +14,6 @@ export const registerClinic = async (
   const registerBodySchema = z
     .object({
       name: z.string(),
-      specialty: z.array(
-        z.object({
-          value: z.string(),
-          label: z.string(),
-        })
-      ),
       healthInsurance: z.array(
         z.object({
           value: z.string(),
@@ -59,7 +53,6 @@ export const registerClinic = async (
 
   const {
     name,
-    specialty,
     healthInsurance,
     phone,
     cellPhone,
@@ -83,7 +76,6 @@ export const registerClinic = async (
 
     const { clinic } = await registerClinicUseCase.execute({
       name,
-      specialty,
       healthInsurance,
       phone,
       cellPhone,

--- a/src/http/routes/clinicRoutes.ts
+++ b/src/http/routes/clinicRoutes.ts
@@ -1,10 +1,10 @@
 import { FastifyInstance } from "fastify";
-import { verifyJwt } from "../middlewares/verify-jwt";
 import { registerClinic } from "../controllers/clinic/registerClinic";
 import { activateClinic } from "../controllers/clinic/activateClinic";
 import { resendActivationEmail } from "../controllers/clinic/resendActivationEmail";
 import { getClinicDetails } from "../controllers/clinic/getClinicDetails";
 import { getAllActiveClinics } from "../controllers/clinic/getAllActiveClinics";
+import { getClinicSpecialties } from "../controllers/clinic/getClinicSpecialties";
 
 export const clinicRoutes = async (app: FastifyInstance) => {
   app.post("/clinics", registerClinic);
@@ -12,4 +12,5 @@ export const clinicRoutes = async (app: FastifyInstance) => {
   app.post("/clinics/resend-activation", resendActivationEmail);
   app.get("/clinics/:id", getClinicDetails);
   app.get("/clinics/active", getAllActiveClinics);
+  app.get("/clinics/:clinicId/specialties", getClinicSpecialties);
 };

--- a/src/http/routes/clinicRoutes.ts
+++ b/src/http/routes/clinicRoutes.ts
@@ -5,6 +5,7 @@ import { resendActivationEmail } from "../controllers/clinic/resendActivationEma
 import { getClinicDetails } from "../controllers/clinic/getClinicDetails";
 import { getAllActiveClinics } from "../controllers/clinic/getAllActiveClinics";
 import { getClinicSpecialties } from "../controllers/clinic/getClinicSpecialties";
+import { getClinicsByProximity } from "../controllers/clinic/getClinicsByProximity";
 
 export const clinicRoutes = async (app: FastifyInstance) => {
   app.post("/clinics", registerClinic);
@@ -13,4 +14,5 @@ export const clinicRoutes = async (app: FastifyInstance) => {
   app.get("/clinics/:id", getClinicDetails);
   app.get("/clinics/active", getAllActiveClinics);
   app.get("/clinics/:clinicId/specialties", getClinicSpecialties);
+  app.post("/clinics/proximity", getClinicsByProximity);
 };

--- a/src/repositories/in-memory/in-memory-clinics-repository.ts
+++ b/src/repositories/in-memory/in-memory-clinics-repository.ts
@@ -1,10 +1,9 @@
-import { Clinic, ClinicHealthInsurance, ClinicSpecialty, Prisma } from "@prisma/client";
+import { Clinic, ClinicHealthInsurance, Prisma } from "@prisma/client";
 import { ClinicsRepository } from "../clinics-repository";
 import { randomNumberWithDigits } from "@/utils/random-number-generate";
 
 export class InMemoryClinicsRepository implements ClinicsRepository {
   public items: Clinic[] = [];
-  public specialtyItems: ClinicSpecialty[] = [];
   public healthInsuranceItems: ClinicHealthInsurance[] = [];
 
   async findById(id: number): Promise<Clinic | null> {
@@ -19,14 +18,9 @@ export class InMemoryClinicsRepository implements ClinicsRepository {
       return null;
     }
 
-    const specialty = this.specialtyItems.filter(item => item.clinicId === id);
     const healthInsurance = this.healthInsuranceItems.filter(item => item.clinicId === id);
 
-    return {
-      ...clinic,
-      specialty,
-      healthInsurance,
-    };
+    return { ...clinic, healthInsurance };
   }
 
   async findByEmail(email: string): Promise<Clinic | null> {
@@ -66,23 +60,6 @@ export class InMemoryClinicsRepository implements ClinicsRepository {
 
     this.items.push(clinic);
 
-    if (data.specialty && data.specialty.create) {
-      const specialties = Array.isArray(data.specialty.create)
-        ? data.specialty.create
-        : [data.specialty.create];
-
-      specialties.forEach(specialty => {
-        const newSpecialty: ClinicSpecialty = {
-          id: randomNumberWithDigits(),
-          value: specialty.value,
-          label: specialty.label,
-          clinicId: clinic.id
-        };
-
-        this.specialtyItems.push(newSpecialty);
-      });
-    }
-
     if (data.healthInsurance && data.healthInsurance.create) {
       const insurances = Array.isArray(data.healthInsurance.create)
         ? data.healthInsurance.create
@@ -105,13 +82,8 @@ export class InMemoryClinicsRepository implements ClinicsRepository {
 
   async findAllWithDetails() {
     return this.items.map(clinic => {
-      const specialty = this.specialtyItems.filter(item => item.clinicId === clinic.id);
       const healthInsurance = this.healthInsuranceItems.filter(item => item.clinicId === clinic.id);
-      return {
-        ...clinic,
-        specialty,
-        healthInsurance,
-      };
+      return { ...clinic, healthInsurance };
     });
   }
 }

--- a/src/repositories/prisma/prisma-clinics-repository.ts
+++ b/src/repositories/prisma/prisma-clinics-repository.ts
@@ -62,13 +62,6 @@ export class PrismaClinicsRepository implements ClinicsRepository {
     const clinic = await prisma.clinic.findUnique({
       where: { id },
       include: {
-        specialty: {
-          select: {
-            id: true,
-            value: true,
-            label: true,
-          },
-        },
         healthInsurance: {
           select: {
             id: true,
@@ -88,7 +81,6 @@ export class PrismaClinicsRepository implements ClinicsRepository {
         isAuthenticated: true,
       },
       include: {
-        specialty: { select: { id: true, value: true, label: true } },
         healthInsurance: { select: { id: true, value: true, label: true } },
       },
     });

--- a/src/use-cases/modules/clinic/registerClinic.ts
+++ b/src/use-cases/modules/clinic/registerClinic.ts
@@ -77,9 +77,6 @@ export class RegisterClinicUseCase {
 
     const clinic = await this.clinicsRepository.create({
       name,
-      specialty: {
-        create: specialty
-      },
       healthInsurance: {
         create: healthInsurance
       },

--- a/src/use-cases/modules/clinic/registerClinic.ts
+++ b/src/use-cases/modules/clinic/registerClinic.ts
@@ -5,10 +5,6 @@ import { Clinic } from "@prisma/client";
 
 interface IRegisterClinic {
   name: string;
-  specialty: {
-    value: string;
-    label: string;
-  }[];
   healthInsurance: {
     value: string;
     label: string;
@@ -41,7 +37,6 @@ export class RegisterClinicUseCase {
 
   execute = async ({
     name,
-    specialty,
     healthInsurance,
     phone,
     cellPhone,

--- a/src/use-cases/tests/clinic/get-clinic-details.spec.ts
+++ b/src/use-cases/tests/clinic/get-clinic-details.spec.ts
@@ -31,12 +31,6 @@ describe("Get Clinic Details Use Case", () => {
       neighborhood: "Centro",
       complement: "Apto 101",
       isAuthenticated: true,
-      specialty: {
-        create: [
-          { value: "cardiology", label: "Cardiologia" },
-          { value: "dermatology", label: "Dermatologia" }
-        ]
-      },
       healthInsurance: {
         create: [
           { value: "unimed", label: "Unimed" },
@@ -51,7 +45,6 @@ describe("Get Clinic Details Use Case", () => {
     expect(foundClinic?.id).toBe(clinic.id);
     expect(foundClinic?.name).toBe("Clínica Teste");
     expect(foundClinic?.email).toBe("test@example.com");
-    expect(foundClinic?.specialty).toHaveLength(2);
     expect(foundClinic?.healthInsurance).toHaveLength(2);
   });
 

--- a/src/use-cases/tests/clinic/registerClinic.spec.ts
+++ b/src/use-cases/tests/clinic/registerClinic.spec.ts
@@ -16,7 +16,6 @@ describe("Register Clinic Use Case", () => {
   it("Should be able to register a clinic", async () => {
     const { clinic } = await sut.execute({
       name: "Clinica Teste",
-      specialty: [{ value: "cirurgia", label: "Cirurgia" }],
       healthInsurance: [{ value: "unimed", label: "Unimed" }],
       phone: "11989234518",
       cellPhone: "11989234518",
@@ -41,7 +40,6 @@ describe("Register Clinic Use Case", () => {
   it("Should hash clinic password upon registration", async () => {
     const { clinic } = await sut.execute({
       name: "Clinica Teste",
-      specialty: [{ value: "cirurgia", label: "Cirurgia" }],
       healthInsurance: [{ value: "unimed", label: "Unimed" }],
       phone: "11989234518",
       cellPhone: "11989234518",
@@ -70,7 +68,6 @@ describe("Register Clinic Use Case", () => {
 
     await sut.execute({
       name: "Clinica Teste",
-      specialty: [{ value: "cirurgia", label: "Cirurgia" }],
       healthInsurance: [{ value: "unimed", label: "Unimed" }],
       phone: "11989234518",
       cellPhone: "11989234518",
@@ -92,7 +89,6 @@ describe("Register Clinic Use Case", () => {
     await expect(() =>
       sut.execute({
         name: "Clinica Teste",
-        specialty: [{ value: "cirurgia", label: "Cirurgia" }],
         healthInsurance: [{ value: "unimed", label: "Unimed" }],
         phone: "11989234518",
         cellPhone: "11989234518",


### PR DESCRIPTION
### **Resumo**

* Adicionado `GET /clinics/:clinicId/specialties` — retorna especialidades distintas dos médicos autenticados da clínica.
* Adicionado `POST /clinics/proximity` — recebe endereço/raio e retorna clínicas dentro do raio, ordenadas por distância.
* Removido o modelo `ClinicSpecialty` do schema Prisma e todas as suas referências.
* Especialidades foram desvinculadas de `Clinic` — agora obtidas via médicos (medics).
* Repositórios em memória atualizados para remover tratamento de `specialties`.
* Lógica de cadastro/atualização de clinics atualizada para eliminar campos/fluxos de `specialties`.
* Controllers atualizados — campo `specialty` removido de payloads/responses de clinic.
* Swagger atualizado com novos schemas/responses para specialties.
* Removidas referências a `clinic.specialty` no código e na documentação.
* Adicionada dependência `geolib` (e typings) para cálculos de distância geoespacial.
